### PR TITLE
Remove redis port from cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ docker-compose up
 
 And run the statsquid top utility to view the streamed stats in real-time:
 ```bash
-docker run -ti --link statsquid_redis_1:redis bcicen/statsquid top --redis-host redis
+docker run -ti --link statsquid_redis_1:redis bcicen/statsquid top --redis redis
 ```
 
 ![top][top]
@@ -31,21 +31,21 @@ docker run -ti --link statsquid_redis_1:redis bcicen/statsquid top --redis-host 
 
 A single statsquid agent can be started on every Docker host you wish to collect stats from by running:
 ```bash
-docker run -td -v /var/run/docker.sock:/var/run/docker.sock bcicen/statsquid agent --redis-host redis.mydomain.com
+docker run -td -v /var/run/docker.sock:/var/run/docker.sock bcicen/statsquid agent --redis redis.mydomain.com
 ```
 
 ## Master
 
 A statquid master connects to the common redis instance and listens for new stats, storing them for persistence
 ```bash
-docker run -td bcicen/statsquid master --redis-host redis.mydomain.com
+docker run -td bcicen/statsquid master --redis redis.mydomain.com
 ```
 
 ## Top
 
 Statsquid comes with a curses-based top utility that can be used to view the aggregated stats in real time.
 ```bash
-docker run -ti bcicen/statsquid top --redis-host redis.mydomain.com
+docker run -ti bcicen/statsquid top --redis redis.mydomain.com
 ```
 
 Statsquid top supports filtering by host and container name/id, sorting by field, and cumulative vs incremental views. Hit 'h' for a full list of features.
@@ -57,16 +57,13 @@ Statsquid supports the following options:
   --docker-host DOCKER_HOST
                         docker host to connect to (default:
                         /var/run/docker.sock) (agent only)
-  --redis-host REDIS_HOST
+  --redis REDIS_HOST
                         redis host to connect to (default: 127.0.0.1)
-  --redis-port REDIS_PORT
-                        redis port to connect on (default: 6379)
 ```
 Likewise, any of the below environmental variables will supersede its equivalent command line option:
 ```
 DOCKER_HOST
-STATSQUID_REDIS_HOST
-STATSQUID_REDIS_PORT
+STATSQUID_REDIS
 ```
 
 # Improvements

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ agent:
   volumes:
     - /var/run/docker.sock:/var/run/docker.sock
   environment:
-    STATSQUID_REDIS_HOST: "redis"
+    STATSQUID_REDIS: "redis"
 
 master:
   image: bcicen/statsquid:latest
@@ -14,7 +14,7 @@ master:
   links:
     - redis:redis
   environment:
-    STATSQUID_REDIS_HOST: "redis"
+    STATSQUID_REDIS: "redis"
 
 redis:
   image: redis:2.8

--- a/statsquid/cli.py
+++ b/statsquid/cli.py
@@ -8,8 +8,8 @@ from collector import StatCollector
 log = logging.getLogger('statsquid')
 
 def main():
-    envvars = { 'STATSQUID_REDIS_HOST' : 'redis_host',
-                'DOCKER_HOST'          : 'docker_host' }
+    envvars = { 'STATSQUID_REDIS' : 'redis_host',
+                'DOCKER_HOST'     : 'docker_host' }
 
     common_parser = ArgumentParser(add_help=False)
     common_parser.add_argument('--redis',

--- a/statsquid/cli.py
+++ b/statsquid/cli.py
@@ -12,8 +12,8 @@ def main():
                 'DOCKER_HOST'          : 'docker_host' }
 
     common_parser = ArgumentParser(add_help=False)
-    common_parser.add_argument('--redis-host',
-                        dest='redis_host',
+    common_parser.add_argument('--redis',
+                        dest='redis',
                         help='redis host to connect to (127.0.0.1:6379)',
                         default='127.0.0.1:6379')
 
@@ -39,10 +39,10 @@ def main():
     [ args.__setattr__(v,os.getenv(k)) for k,v \
             in envvars.iteritems() if os.getenv(k) ]
 
-    if ':' in args.redis_host:
-        redis_host,redis_port = args.redis_host.split(':')
+    if ':' in args.redis:
+        redis_host,redis_port = args.redis.split(':')
     else:
-        redis_host = args.redis_host
+        redis_host = args.redis
         redis_port = 6379
 
     if args.subcommand == 'top':

--- a/statsquid/cli.py
+++ b/statsquid/cli.py
@@ -9,18 +9,13 @@ log = logging.getLogger('statsquid')
 
 def main():
     envvars = { 'STATSQUID_REDIS_HOST' : 'redis_host',
-                'STATSQUID_REDIS_PORT' : 'redis_port',
                 'DOCKER_HOST'          : 'docker_host' }
 
     common_parser = ArgumentParser(add_help=False)
     common_parser.add_argument('--redis-host',
                         dest='redis_host',
-                        help='redis host to connect to (127.0.0.1)',
-                        default='127.0.0.1')
-    common_parser.add_argument('--redis-port',
-                        dest='redis_port',
-                        help='redis port to connect on (6379)',
-                        default='6379')
+                        help='redis host to connect to (127.0.0.1:6379)',
+                        default='127.0.0.1:6379')
 
     parser = ArgumentParser(description='statsquid %s' % (__version__))
     subparsers = parser.add_subparsers(description='statsquid subcommands',
@@ -44,17 +39,22 @@ def main():
     [ args.__setattr__(v,os.getenv(k)) for k,v \
             in envvars.iteritems() if os.getenv(k) ]
 
+    if ':' in args.redis_host:
+        redis_host,redis_port = args.redis_host.split(':')
+    else:
+        redis_host = args.redis_host
+        redis_port = 6379
+
     if args.subcommand == 'top':
-        StatSquidTop(redis_host=args.redis_host,redis_port=args.redis_port)
+        StatSquidTop(redis_host=redis_host,redis_port=redis_port)
 
     if args.subcommand == 'master':
-        s = StatListener(redis_host=args.redis_host,
-                         redis_port=args.redis_port)
+        s = StatListener(redis_host=redis_host,redis_port=redis_port)
 
     if args.subcommand == 'agent':
         s = StatCollector(args.docker_host,
-                          redis_host=args.redis_host,
-                          redis_port=args.redis_port)
+                          redis_host=redis_host,
+                          redis_port=redis_port)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Removing redis-port option and env var, replacing with --redis and the ability to specify port in string
